### PR TITLE
Improves internal link navigation

### DIFF
--- a/template/static/styles/site.oblivion.css
+++ b/template/static/styles/site.oblivion.css
@@ -728,7 +728,7 @@ dd {
 }
 dt > span {
   display: block;
-  margin-top: 100px;
+  padding-top: 100px;
 }
 .dl-horizontal {
   *zoom: 1;


### PR DESCRIPTION
This improves internal link navigation and scroll spy behavior by changing `margin-top` to `padding-top`.
